### PR TITLE
fix(schema): use UserContact constructor instead of type assertion

### DIFF
--- a/src/google/client.ts
+++ b/src/google/client.ts
@@ -3,7 +3,7 @@ import { NodeHttpClient } from "@effect/platform-node";
 import { Data, Effect, Schema } from "effect";
 import { JWT } from "google-auth-library";
 import { AppConfig } from "../config";
-import type { UserContact } from "../core/schema";
+import { UserContact } from "../core/schema";
 
 // Schema for Google Sheets API response
 class GoogleSheetsResponse extends Schema.Class<GoogleSheetsResponse>("GoogleSheetsResponse")({
@@ -90,12 +90,17 @@ export const extractUserContacts = (
       const email = row[columnMapping.emailIndex]?.trim();
       const phone = row[columnMapping.phoneIndex]?.trim();
 
-      return {
-        name,
-        ...(email ? { email } : {}),
-        ...(phone ? { phone } : {}),
-      } as UserContact;
-    });
+      return { name, email, phone };
+    })
+    .filter((contact) => contact.name.length > 0)
+    .map(
+      (contact) =>
+        new UserContact({
+          name: contact.name,
+          ...(contact.email ? { email: contact.email } : {}),
+          ...(contact.phone ? { phone: contact.phone } : {}),
+        })
+    );
 };
 
 export class GoogleSheetsService extends Effect.Service<GoogleSheetsService>()(


### PR DESCRIPTION
## Summary
- Fix Schema.Class instantiation bug causing deployment failures
- `extractUserContacts` was creating plain objects with type assertions instead of using `new UserContact({...})`
- When `SyncResultFailedRow` validated its `contact` field, it expected a real `UserContact` instance

## Changes
- Import `UserContact` as class (not type only) in google/client.ts
- Use `new UserContact({...})` to create proper instances
- Filter out rows with empty names before construction (Schema.NonEmptyTrimmedString requirement)

## Test plan
- [x] All 151 tests pass
- [x] TypeScript compiles without errors
- [ ] Deploy to Fly.io and verify sync works

🤖 Generated with [Claude Code](https://claude.com/claude-code)