### PR TITLE
fix(scheduler): properly implement retry for network errors

### DIFF
--- a/src/scheduler/cron.ts
+++ b/src/scheduler/cron.ts
@@ -93,7 +93,7 @@ export class CronService extends Effect.Service<CronService>()("CronService", {
       );
     }).pipe(Effect.interruptible);
 
-    return { syncOnce, runHourly };
+    return { syncOnce, syncWithRetry, runHourly };
   }),
   dependencies: [SyncService.Default, NotifyService.Default],
 }) {}


### PR DESCRIPTION
## Summary
- Fix retry logic that wasn't working because `syncOnce` caught all errors internally
- Restructure to separate `syncCore` (can fail) from `syncWithRetry` (with retry + error handling)
- Retries 3 times with exponential backoff (2s, 4s, 8s)

## Changes
- `syncCore`: Core sync operation that can fail (for retry to work)
- `syncWithRetry`: Production version with retry + notifications
- `syncOnce`: Test version without retry (for unit tests)

## Test plan
- [x] All 151 tests pass
- [x] TypeScript compiles without errors
- [ ] Deploy and verify retry works on network errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)