### PR TITLE
fix(deploy): disable autostop for cron-based service

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -18,9 +18,9 @@ primary_region = 'sjc'
 [http_service]
   internal_port = 8080
   force_https = true
-  auto_stop_machines = 'stop'
+  auto_stop_machines = 'off'
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
   processes = ['app']
 
 [[vm]]


### PR DESCRIPTION
## Summary
- Set `auto_stop_machines = 'off'` to prevent autostop on idle
- Set `min_machines_running = 1` to keep cron job running

This fixes the issue where the cron-based service keeps autostopping because there's no HTTP traffic.

## Test plan
- Deploy and verify machine stays running
- Verify cron job runs on schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)