### PR TITLE
fix(scheduler): increase network startup delay to 15s

### DIFF
--- a/src/scheduler/cron.ts
+++ b/src/scheduler/cron.ts
@@ -78,8 +78,9 @@ export class CronService extends Effect.Service<CronService>()("CronService", {
       yield* Console.log("[INFO] Starting cron scheduler (hourly at :00)");
 
       // Wait for network to be ready before first sync
-      yield* Console.log("[INFO] Waiting 3s for network initialization...");
-      yield* Effect.sleep(Duration.seconds(3));
+      // Fly.io network/DNS can take 15+ seconds to fully initialize
+      yield* Console.log("[INFO] Waiting 15s for network initialization...");
+      yield* Effect.sleep(Duration.seconds(15));
 
       // Run once immediately (with retry)
       yield* syncWithRetry;


### PR DESCRIPTION
## Summary
Fly.io network/DNS can take longer than 3s to fully initialize, causing Transport errors on startup.

- Increase startup delay from 3s to 15s

## Test plan
- Deploy and verify sync succeeds on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)