### PR TITLE
fix: use FetchHttpClient for Bun compatibility

### DIFF
--- a/src/error/notify.ts
+++ b/src/error/notify.ts
@@ -1,5 +1,4 @@
-import { HttpBody, HttpClient } from "@effect/platform";
-import { NodeHttpClient } from "@effect/platform-node";
+import { FetchHttpClient, HttpBody, HttpClient } from "@effect/platform";
 import { Data, Effect, Schema } from "effect";
 import { AppConfig } from "../config";
 
@@ -123,5 +122,5 @@ export class NotifyService extends Effect.Service<NotifyService>()("NotifyServic
         }),
     };
   }),
-  dependencies: [NodeHttpClient.layerUndici],
+  dependencies: [FetchHttpClient.layer],
 }) {}

--- a/src/google/client.ts
+++ b/src/google/client.ts
@@ -1,5 +1,4 @@
-import { HttpClient, HttpClientRequest } from "@effect/platform";
-import { NodeHttpClient } from "@effect/platform-node";
+import { FetchHttpClient, HttpClient, HttpClientRequest } from "@effect/platform";
 import { Data, Effect, Schema } from "effect";
 import { JWT } from "google-auth-library";
 import { AppConfig } from "../config";
@@ -176,6 +175,6 @@ export class GoogleSheetsService extends Effect.Service<GoogleSheetsService>()(
 
       return { fetchRows, parseUserContacts };
     }),
-    dependencies: [GoogleAuthService.Default, NodeHttpClient.layerUndici],
+    dependencies: [GoogleAuthService.Default, FetchHttpClient.layer],
   }
 ) {}

--- a/src/groupme/client.ts
+++ b/src/groupme/client.ts
@@ -1,5 +1,4 @@
-import { HttpBody, HttpClient, HttpClientRequest } from "@effect/platform";
-import { NodeHttpClient } from "@effect/platform-node";
+import { FetchHttpClient, HttpBody, HttpClient, HttpClientRequest } from "@effect/platform";
 import { Data, Effect, Schema } from "effect";
 import { AppConfig } from "../config";
 
@@ -262,5 +261,5 @@ export class GroupMeService extends Effect.Service<GroupMeService>()("GroupMeSer
 
     return { validateToken, getMembers, addMember };
   }),
-  dependencies: [NodeHttpClient.layerUndici],
+  dependencies: [FetchHttpClient.layer],
 }) {}

--- a/src/health/server.ts
+++ b/src/health/server.ts
@@ -86,11 +86,7 @@ export const waitForNetwork = Effect.gen(function* () {
     );
 
     if (isReady) {
-      yield* Console.log(
-        `[INFO] All services reachable after ${attempt * 2}s, waiting 45s for API backends...`
-      );
-      yield* Effect.sleep(Duration.seconds(45));
-      yield* Console.log("[INFO] Network stabilized, proceeding");
+      yield* Console.log(`[INFO] Network ready after ${attempt * 2}s`);
       return;
     }
 


### PR DESCRIPTION
## Summary
- Replace `NodeHttpClient.layerUndici` with `FetchHttpClient.layer` in all services
- `NodeHttpClient.layerUndici` uses undici which has compatibility issues with Bun runtime, causing Transport errors on all HTTP requests
- Remove unnecessary 45s artificial delay from network readiness check

## Files Changed
- `src/google/client.ts` - GoogleSheetsService
- `src/groupme/client.ts` - GroupMeService  
- `src/error/notify.ts` - NotifyService
- `src/health/server.ts` - Remove artificial delay

## Test plan
- [x] Deployed to Fly.io and verified sync completes successfully
- [x] Discord notifications working
- [x] No more Transport errors on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)