### PR TITLE
chore: disable HA to stay under free tier

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -16,7 +16,7 @@ primary_region = 'sjc'
   force_https = true
   auto_stop_machines = 'off'
   auto_start_machines = true
-  min_machines_running = 1
+  min_machines_running = 0  # Disable auto HA - single machine is fine for this cron job
   processes = ['app']
 
 [[vm]]


### PR DESCRIPTION
## Summary
Disables Fly.io high availability by setting `min_machines_running` to 0, reducing costs to stay within the free tier for this cron-based application.

## Changes
- Set `min_machines_running` from 1 to 0 in fly.toml
- Added inline comment explaining the change (single machine sufficient for cron job)

## Type
- [x] Chore
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Other

## Notes
Since this application runs on a scheduled cron job rather than serving continuous traffic, high availability with multiple machines is unnecessary. Setting to 0 allows Fly.io to auto-start machines when needed while staying within free tier limits.

---
*Auto-generated by Claude. Feel free to edit.*