### PR TITLE
fix: create exclusion file from secret in CI/CD

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -19,6 +19,8 @@ jobs:
     concurrency: deploy-group    # optional: ensure only one action runs at a time
     steps:
       - uses: actions/checkout@v4
+      - name: Create exclusion file
+        run: echo '${{ secrets.SYNC_EXCLUDE_JSON }}' > sync-exclude.json
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - run: flyctl deploy --remote-only
         env:


### PR DESCRIPTION
## Summary
- Fixes CI/CD deployment failure caused by missing `sync-exclude.json` (gitignored)
- Adds workflow step to create the file from `SYNC_EXCLUDE_JSON` secret before Docker build

## Root Cause
The Dockerfile expects `sync-exclude.json` to exist, but it's gitignored since it contains private data. In CI/CD, the file doesn't exist, causing the build to fail.

## Test plan
- [x] Added `SYNC_EXCLUDE_JSON` secret to Infisical (dev + prod)
- [x] Verify deploy succeeds after merge
- [x] Check logs for "Loaded X exclusions from sync-exclude.json"

🤖 Generated with [Claude Code](https://claude.com/claude-code)